### PR TITLE
Adjust admin roadmap layout and ordering

### DIFF
--- a/client/src/components/admin/minimal-data-ai-roadmap.tsx
+++ b/client/src/components/admin/minimal-data-ai-roadmap.tsx
@@ -421,7 +421,7 @@ export default function MinimalDataAIRoadmap() {
   return (
     <section
       aria-label="Data & AI Roadmap"
-      className="mx-auto max-w-2xl px-6 py-2 bg-white text-slate-900 [color-scheme:light]"
+      className="w-full max-w-2xl px-0 py-2 bg-white text-slate-900 [color-scheme:light]"
       style={{
         ['--background' as any]: '0 0% 100%', ['--foreground' as any]: '222.2 84% 4.9%',
         ['--card' as any]: '0 0% 100%', ['--card-foreground' as any]: '222.2 84% 4.9%',
@@ -448,7 +448,7 @@ export default function MinimalDataAIRoadmap() {
         <div key={cat.id} id={slugify(cat.title)} className="mb-2">
           <Accordion type="single" collapsible>
             <AccordionItem value={cat.id}>
-              <AccordionTrigger className="py-1 text-base font-medium hover:no-underline">
+              <AccordionTrigger className="py-1 text-sm font-medium text-left hover:no-underline">
                 <div className="w-full">{cat.title}</div>
               </AccordionTrigger>
               <AccordionContent className="pt-1">
@@ -456,7 +456,7 @@ export default function MinimalDataAIRoadmap() {
                   {cat.skills.length ? (
                     cat.skills.map((skill) => (
                       <details key={skill.id} className="group">
-                        <summary className="cursor-pointer list-none py-1 text-[15px] text-slate-700 hover:text-slate-900">{skill.title}</summary>
+                        <summary className="cursor-pointer list-none py-1 text-sm text-slate-700 hover:text-slate-900">{skill.title}</summary>
                         <div className="ml-4 mt-1 divide-y divide-slate-100">
                           {skill.concepts.map((k) => {
                             const savedUrl = conceptLinks[k.id]?.url || k.url;

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -199,7 +199,7 @@ export default function Admin() {
 
   return (
     <div className="min-h-screen p-8 grid lg:grid-cols-[300px_1fr] gap-x-32">
-      <div className="order-1 lg:order-2 mt-[240px]">
+      <div className="order-2 lg:order-2 mt-12 lg:mt-[240px]">
         <div className="flex items-start justify-between">
           <div>
             <h1 className="text-xl font-medium mb-1">Ayanna Seals, PhD</h1>
@@ -239,7 +239,7 @@ export default function Admin() {
           <MinimalDataAIRoadmap />
         </div>
       </div>
-      <div className="order-2 lg:order-1 mt-8 lg:mt-[240px] lg:ml-[120px]">
+      <div className="order-1 lg:order-1 mt-8 lg:mt-[240px] lg:ml-[120px]">
         <ProjectList projects={projects || []} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- align the embedded Data & AI Roadmap section with the profile column instead of centering it
- reduce the roadmap heading sizes for a slightly smaller typographic scale
- reorder the admin layout so the roadmap appears beneath the portfolio list on mobile

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d030c2c1cc8332ba9cc4eab7d94a65