### PR TITLE
Enable inline editing of portfolio items

### DIFF
--- a/client/src/components/project-list.tsx
+++ b/client/src/components/project-list.tsx
@@ -12,10 +12,23 @@ interface ProjectListProps {
 }
 
 export default function ProjectList({ projects }: ProjectListProps) {
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const [hoveredProject, setHoveredProject] = useState<Project | null>(null);
+  const [editableProjects, setEditableProjects] = useState<Project[]>(projects);
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [hoveredProjectId, setHoveredProjectId] = useState<number | null>(null);
   const [cursorProgress, setCursorProgress] = useState(0);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [editingField, setEditingField] = useState<
+    | {
+        projectId: number;
+        field: "title" | "year";
+        value: string;
+      }
+    | null
+  >(null);
+
+  useEffect(() => {
+    setEditableProjects(projects);
+  }, [projects]);
 
   useEffect(() => {
     const checkDesktop = () => {
@@ -29,15 +42,15 @@ export default function ProjectList({ projects }: ProjectListProps) {
 
   const handleMouseEnter = (project: Project) => {
     if (!isDesktop) return;
-    setHoveredProject(project);
+    setHoveredProjectId(project.id);
   };
 
   const handleMouseLeave = () => {
     if (!isDesktop) return;
-    setHoveredProject(null);
+    setHoveredProjectId(null);
   };
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!isDesktop) return;
     const element = e.currentTarget;
     const rect = element.getBoundingClientRect();
@@ -48,15 +61,68 @@ export default function ProjectList({ projects }: ProjectListProps) {
 
   const handleClick = (project: Project) => {
     if (isDesktop) return;
-    setSelectedProject(project);
+    if (editingField) return;
+    setSelectedProjectId(project.id);
   };
 
   const handleClose = () => {
-    setSelectedProject(null);
-    setHoveredProject(null);
+    setSelectedProjectId(null);
+    setHoveredProjectId(null);
   };
 
-  const projectsByYear = projects.reduce((acc, project) => {
+  const startEditing = (project: Project, field: "title" | "year") => {
+    setEditingField({
+      projectId: project.id,
+      field,
+      value: field === "year" ? String(project.year) : project.title,
+    });
+  };
+
+  const cancelEditing = () => {
+    setEditingField(null);
+  };
+
+  const commitEditing = () => {
+    if (!editingField) return;
+
+    const trimmedValue = editingField.value.trim();
+
+    setEditableProjects((prev) =>
+      prev.map((project) => {
+        if (project.id !== editingField.projectId) return project;
+
+        if (editingField.field === "title") {
+          if (!trimmedValue) {
+            return project;
+          }
+          return { ...project, title: trimmedValue };
+        }
+
+        const parsedYear = parseInt(trimmedValue, 10);
+        if (Number.isNaN(parsedYear)) {
+          return project;
+        }
+        return { ...project, year: parsedYear };
+      }),
+    );
+
+    setEditingField(null);
+  };
+
+  const handleInputChange = (value: string) => {
+    setEditingField((current) =>
+      current ? { ...current, value } : current,
+    );
+  };
+
+  const activeProjectId = hoveredProjectId ?? selectedProjectId;
+
+  const activeProject =
+    activeProjectId != null
+      ? editableProjects.find((project) => project.id === activeProjectId) ?? null
+      : null;
+
+  const projectsByYear = editableProjects.reduce((acc, project) => {
     if (!acc[project.year]) {
       acc[project.year] = [];
     }
@@ -68,25 +134,90 @@ export default function ProjectList({ projects }: ProjectListProps) {
     .map(Number)
     .sort((a, b) => b - a);
 
-  const activeProject = hoveredProject || selectedProject;
-
   return (
     <div className="relative">
       <div className="space-y-4 relative z-20">
         {years.map((year) => (
           <div key={year}>
             {projectsByYear[year].map((project) => (
-              <motion.button
+              <motion.div
                 key={project.id}
                 onClick={() => handleClick(project)}
                 onMouseEnter={() => handleMouseEnter(project)}
                 onMouseLeave={handleMouseLeave}
                 onMouseMove={handleMouseMove}
-                className="w-full text-left py-2 flex justify-between items-center group"
+                className="w-full text-left py-2 flex justify-between items-center group cursor-pointer"
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleClick(project);
+                  }
+                }}
               >
-                <span className="text-base font-medium">{project.title}</span>
-                <span className="text-sm text-muted-foreground">{year}</span>
-              </motion.button>
+                <span
+                  className="text-base font-medium cursor-text"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    startEditing(project, "title");
+                  }}
+                >
+                  {editingField?.projectId === project.id && editingField.field === "title" ? (
+                    <input
+                      className="bg-transparent border-b border-muted-foreground focus:border-foreground focus:outline-none"
+                      value={editingField.value}
+                      onChange={(event) => handleInputChange(event.target.value)}
+                      onBlur={commitEditing}
+                      onKeyDown={(event) => {
+                        event.stopPropagation();
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          commitEditing();
+                        }
+                        if (event.key === "Escape") {
+                          event.preventDefault();
+                          cancelEditing();
+                        }
+                      }}
+                      autoFocus
+                    />
+                  ) : (
+                    project.title
+                  )}
+                </span>
+                <span
+                  className="text-sm text-muted-foreground cursor-text"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    startEditing(project, "year");
+                  }}
+                >
+                  {editingField?.projectId === project.id && editingField.field === "year" ? (
+                    <input
+                      className="w-16 bg-transparent border-b border-muted-foreground focus:border-foreground focus:outline-none"
+                      value={editingField.value}
+                      onChange={(event) => handleInputChange(event.target.value)}
+                      onBlur={commitEditing}
+                      onKeyDown={(event) => {
+                        event.stopPropagation();
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          commitEditing();
+                        }
+                        if (event.key === "Escape") {
+                          event.preventDefault();
+                          cancelEditing();
+                        }
+                      }}
+                      autoFocus
+                      inputMode="numeric"
+                    />
+                  ) : (
+                    project.year
+                  )}
+                </span>
+              </motion.div>
             ))}
           </div>
         ))}


### PR DESCRIPTION
## Summary
- allow portfolio list items to be edited inline by tracking editable project state
- render titles and years as inline inputs that save on blur or Enter with Escape to cancel
- keep hover/selection logic in sync by storing active project ids so the viewer updates after edits

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d05e596b908332a3c6fdb573c9d9f1