### PR TITLE
Restrict project edits to admin sessions

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -240,7 +240,7 @@ export default function Admin() {
         </div>
       </div>
       <div className="order-1 lg:order-1 mt-8 lg:mt-[240px] lg:ml-[120px]">
-        <ProjectList projects={projects || []} />
+        <ProjectList projects={projects || []} allowEditing />
       </div>
     </div>
   );

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,8 +1,9 @@
-import { projects, type Project, type InsertProject } from "@shared/schema";
+import { type Project, type InsertProject, type UpdateProject } from "@shared/schema";
 
 export interface IStorage {
   getProjects(): Promise<Project[]>;
   getProject(id: number): Promise<Project | undefined>;
+  updateProject(id: number, updates: UpdateProject): Promise<Project | undefined>;
 }
 
 export class MemStorage implements IStorage {
@@ -54,6 +55,21 @@ export class MemStorage implements IStorage {
 
   async getProject(id: number): Promise<Project | undefined> {
     return this.projects.get(id);
+  }
+
+  async updateProject(id: number, updates: UpdateProject): Promise<Project | undefined> {
+    const existingProject = this.projects.get(id);
+    if (!existingProject) {
+      return undefined;
+    }
+
+    const updatedProject: Project = {
+      ...existingProject,
+      ...updates,
+    };
+
+    this.projects.set(id, updatedProject);
+    return updatedProject;
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,5 +21,19 @@ export const insertProjectSchema = createInsertSchema(projects).pick({
   order: true,
 });
 
+export const updateProjectSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, { message: "Title is required" })
+      .optional(),
+    year: z.coerce.number().int({ message: "Year must be an integer" }).optional(),
+  })
+  .refine((data) => data.title !== undefined || data.year !== undefined, {
+    message: "At least one field must be provided",
+  });
+
 export type InsertProject = z.infer<typeof insertProjectSchema>;
+export type UpdateProject = z.infer<typeof updateProjectSchema>;
 export type Project = typeof projects.$inferSelect;


### PR DESCRIPTION
## Summary
- gate inline project editing behind a new allowEditing flag in ProjectList
- reset any editing state when editing is disabled to prevent stray inputs
- enable editing only in the authenticated admin view

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d061b2a1a88332bef9a2e11bbe87b6